### PR TITLE
Add support for Ufocoin

### DIFF
--- a/pybitcoin/privatekey.py
+++ b/pybitcoin/privatekey.py
@@ -146,3 +146,6 @@ class LitecoinPrivateKey(BitcoinPrivateKey):
 
 class NamecoinPrivateKey(BitcoinPrivateKey):
     _pubkeyhash_version_byte = 52
+    
+class UfocoinPrivateKey(BitcoinPrivateKey):
+    _pubkeyhash_version_byte = 27


### PR DESCRIPTION
Add support for Ufocoin to get proper private key from invalid WIF generation on old paper wallet.